### PR TITLE
Auto-start local databases when migrations run

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,8 @@ pnpm migrate
 pnpm seed
 ```
 
+- If this is your first run, make sure PostgreSQL and MongoDB are reachable before invoking `pnpm migrate`. The migration helper will automatically attempt to launch `postgres` and `mongo` from `infra/docker-compose.yml` when Docker Compose is available; otherwise, start your local services (for example, Windows users without Docker can install PostgreSQL and MongoDB locally and point `POSTGRES_URL`/`MONGO_URL` at `localhost`).
+
 - Web (Next.js): http://localhost:3000
 - API (Express): http://localhost:4000/api
 - Recs (Flask): http://127.0.0.1:5000/health
@@ -56,6 +58,24 @@ yarn seed # or pnpm seed
 # Run tests
 pnpm -r test
 ```
+
+### Seeding demo data
+
+The seeding script lives at `scripts/seed.ts` and is wired to the root `pnpm seed` command. It wipes and repopulates the MongoDB
+catalog and Prisma-backed PostgreSQL tables with demo products, events, and two ready-to-use accounts:
+
+- Admin: `admin@example.com` / `admin123`
+- Customer: `user@example.com` / `user123`
+
+Before running the seed, ensure the API environment variables point at reachable PostgreSQL and MongoDB instances (the script
+defaults to `MONGO_URL=mongodb://localhost:27017/shop` if unset) and apply the latest migrations:
+
+```bash
+pnpm migrate
+pnpm seed          # or pnpm --filter ./apps/api run seed
+```
+
+The operation is idempotent—re-running it will clear the existing demo data and load a fresh set.
 
 See `docs/ARCHITECTURE.md`, `docs/API_CONTRACTS.md`, and `docs/RUNBOOK.md`.
 

--- a/apps/web/app/page.tsx
+++ b/apps/web/app/page.tsx
@@ -19,12 +19,23 @@ type Recommendation = {
   productId?: string;
 };
 
+type ProductVariant = {
+  variantId?: string;
+  label?: string;
+  price?: number;
+  stock?: number;
+  options?: Record<string, string>;
+  images?: string[];
+};
+
 type Product = {
   _id: string;
   title: string;
   slug: string;
   price: number;
   images?: string[];
+  defaultVariantId?: string;
+  variants?: ProductVariant[];
 };
 
 type Category = { _id: string; name: string; slug?: string };
@@ -95,6 +106,17 @@ export default function Page() {
   const rotationRef = useRef<number>(Date.now());
   const { addItem, pending } = useCartState();
   const [productErrors, setProductErrors] = useState<Record<string, string>>({});
+
+  const getDefaultVariant = (product: Product): ProductVariant | undefined => {
+    if (Array.isArray(product.variants) && product.variants.length) {
+      if (product.defaultVariantId) {
+        const explicit = product.variants.find((variant) => variant.variantId === product.defaultVariantId);
+        if (explicit) return explicit;
+      }
+      return product.variants[0];
+    }
+    return undefined;
+  };
 
   useEffect(() => {
     apiGet<{ ok: boolean }>('/health')

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "dev:api": "pnpm --filter ./apps/api dev",
     "dev:web": "pnpm --filter ./apps/web dev",
     "dev:recs": "node scripts/run-recs-dev.mjs",
-    "dev": "concurrently -n api,web,recs -c green,cyan,yellow \"pnpm dev:api\" \"pnpm dev:web\" \"pnpm dev:recs\"",
+    "dev": "node scripts/run-dev.mjs",
     "build": "pnpm -r build",
     "test": "pnpm -r test",
     "migrate": "tsx scripts/migrate.ts",
@@ -15,6 +15,7 @@
   },
   "devDependencies": {
     "concurrently": "^8.2.2",
+    "dotenv": "^16.4.5",
     "tsx": "^4.19.1"
   },
   "pnpm": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -11,6 +11,9 @@ importers:
       concurrently:
         specifier: ^8.2.2
         version: 8.2.2
+      dotenv:
+        specifier: ^16.4.5
+        version: 16.6.1
       tsx:
         specifier: ^4.19.1
         version: 4.20.6
@@ -208,6 +211,10 @@ packages:
   date-fns@2.30.0:
     resolution: {integrity: sha512-fnULvOpxnC5/Vg3NCiWelDsLiUc9bRwAPs/+LfTLNvetFCtCTN+yQz15C/fs4AwX1R9K5GLtLfn8QW+dWisaAw==}
     engines: {node: '>=0.11'}
+
+  dotenv@16.6.1:
+    resolution: {integrity: sha512-uBq4egWHTcTt33a72vpSG0z3HnPuIl6NqYcTrKEg2azoEyl2hpW0zqlxysq2pK9HlDIHyHyakeYaYnSAwd8bow==}
+    engines: {node: '>=12'}
 
   emoji-regex@8.0.0:
     resolution: {integrity: sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==}
@@ -425,6 +432,8 @@ snapshots:
   date-fns@2.30.0:
     dependencies:
       '@babel/runtime': 7.28.4
+
+  dotenv@16.6.1: {}
 
   emoji-regex@8.0.0: {}
 

--- a/scripts/migrate.ts
+++ b/scripts/migrate.ts
@@ -1,9 +1,184 @@
-import { execSync } from 'node:child_process';
+import { execSync, spawnSync } from 'node:child_process';
+import { existsSync } from 'node:fs';
+import { join } from 'node:path';
+import { URL } from 'node:url';
+import { config as loadEnv } from 'dotenv';
 
-try {
-  execSync('pnpm prisma migrate deploy', { stdio: 'inherit', cwd: 'apps/api' });
-  console.log('Migrations applied');
-} catch (e) {
-  console.error('Migration failed', e);
-  process.exit(1);
+const repoRoot = process.cwd();
+const apiDir = join(repoRoot, 'apps', 'api');
+const composeFile = join(repoRoot, 'infra', 'docker-compose.yml');
+
+// Load environment variables from both the repo root and the API package if available.
+loadEnv();
+const apiEnvPath = join(repoRoot, 'apps', 'api', '.env');
+if (existsSync(apiEnvPath)) {
+  loadEnv({ path: apiEnvPath, override: false });
 }
+
+function describeDbTarget(rawUrl: string | undefined | null) {
+  if (!rawUrl) {
+    return 'the configured PostgreSQL instance';
+  }
+
+  try {
+    const parsed = new URL(rawUrl);
+    const host = parsed.hostname || parsed.host || 'localhost';
+    const port = parsed.port || '5432';
+    return `${host}:${port}`;
+  } catch {
+    return rawUrl;
+  }
+}
+
+const dbUrl = process.env.POSTGRES_URL ?? process.env.DATABASE_URL ?? null;
+
+function resolvePnpmInvocation(args: string[]) {
+  const execPath = process.env.npm_execpath ?? '';
+  if (execPath && execPath.endsWith('.cjs')) {
+    return { command: process.execPath, args: [execPath, ...args] } as const;
+  }
+  return { command: execPath || 'pnpm', args } as const;
+}
+
+type MigrateResult =
+  | { success: true }
+  | { success: false; combinedMessage: string; exitCode: number };
+
+function runMigrations(): MigrateResult {
+  const invocation = resolvePnpmInvocation(['prisma', 'migrate', 'deploy']);
+  const result = spawnSync(invocation.command, invocation.args, {
+    cwd: apiDir,
+    encoding: 'utf-8',
+  });
+
+  if (result.stdout) {
+    process.stdout.write(result.stdout);
+  }
+  if (result.stderr) {
+    process.stderr.write(result.stderr);
+  }
+
+  const exitCode = typeof result.status === 'number' ? result.status : 1;
+
+  if (!result.error && result.status === 0 && !result.signal) {
+    console.log('Migrations applied');
+    return { success: true };
+  }
+
+  const combinedMessage = [result.stdout ?? '', result.stderr ?? '', result.error?.message ?? '']
+    .filter(Boolean)
+    .join('\n');
+
+  return {
+    success: false,
+    combinedMessage,
+    exitCode,
+  };
+}
+
+function getDbHost(rawUrl: string | undefined | null) {
+  if (!rawUrl) {
+    return null;
+  }
+
+  try {
+    const parsed = new URL(rawUrl);
+    return parsed.hostname || parsed.host || null;
+  } catch {
+    return null;
+  }
+}
+
+function resolveComposeInvocation() {
+  try {
+    execSync('docker compose version', { stdio: 'ignore' });
+    return { command: 'docker', args: ['compose'] } as const;
+  } catch {
+    // fall through
+  }
+
+  try {
+    execSync('docker-compose --version', { stdio: 'ignore' });
+    return { command: 'docker-compose', args: [] as string[] } as const;
+  } catch {
+    return null;
+  }
+}
+
+const LOCAL_HOSTS = new Set(['postgres', 'localhost', '127.0.0.1', '0.0.0.0']);
+
+function tryAutoStartDatabases(host: string | null) {
+  if (process.env.SKIP_AUTO_START_DB === '1') {
+    return false;
+  }
+
+  if (!host || !LOCAL_HOSTS.has(host)) {
+    return false;
+  }
+
+  if (!existsSync(composeFile)) {
+    return false;
+  }
+
+  const composeInvocation = resolveComposeInvocation();
+  if (!composeInvocation) {
+    console.error(
+      'Docker Compose is not available in PATH, so the migration helper cannot auto-start PostgreSQL. Start your database manually and re-run `pnpm migrate`.',
+    );
+    return false;
+  }
+
+  console.log('PostgreSQL is unreachable. Attempting to start postgres and mongo via Docker Compose...');
+
+  const result = spawnSync(
+    composeInvocation.command,
+    [...composeInvocation.args, '-f', composeFile, 'up', '-d', 'postgres', 'mongo'],
+    { cwd: repoRoot, stdio: 'inherit' },
+  );
+
+  if (result.error) {
+    console.error(`Failed to start Docker Compose services: ${result.error.message}`);
+    return false;
+  }
+
+  if (typeof result.status === 'number' && result.status !== 0) {
+    console.error(`Docker Compose exited with code ${result.status}. Start the databases manually and retry.`);
+    return false;
+  }
+
+  return true;
+}
+
+const dbHost = getDbHost(dbUrl);
+
+let attempt = runMigrations();
+
+if (!attempt.success && attempt.combinedMessage.includes('P1001')) {
+  const autoStarted = tryAutoStartDatabases(dbHost);
+  if (autoStarted) {
+    console.log('Retrying migrations now that the databases are starting...');
+    attempt = runMigrations();
+  }
+}
+
+if (attempt.success) {
+  process.exit(0);
+}
+
+const combinedMessage = attempt.combinedMessage;
+
+if (combinedMessage.includes('Environment variable not found: POSTGRES_URL')) {
+  console.error(
+    'POSTGRES_URL is not set. Copy infra/.env.example to apps/api/.env (or export POSTGRES_URL) so Prisma knows how to reach your database.',
+  );
+} else if (combinedMessage.includes('P1001')) {
+  const target = describeDbTarget(dbUrl);
+  console.error(
+    `Prisma could not reach PostgreSQL at ${target}. ` +
+      'Ensure the database is running (the migration helper will auto-start docker compose if available) and rerun `pnpm migrate`.',
+  );
+} else {
+  console.error('Migration failed');
+}
+
+process.exit(attempt.exitCode);

--- a/scripts/run-dev.mjs
+++ b/scripts/run-dev.mjs
@@ -1,0 +1,253 @@
+#!/usr/bin/env node
+import { createHash } from 'node:crypto';
+import { existsSync, readdirSync, readFileSync, writeFileSync } from 'node:fs';
+import { join, relative } from 'node:path';
+import { spawn } from 'node:child_process';
+
+const repoRoot = process.cwd();
+
+function resolvePnpmInvocation(args) {
+  const execPath = process.env.npm_execpath ?? '';
+  if (execPath && execPath.endsWith('.cjs')) {
+    return { command: process.execPath, args: [execPath, ...args] };
+  }
+  return { command: execPath || 'pnpm', args };
+}
+
+function run(command, args, options = {}) {
+  return new Promise((resolve, reject) => {
+    const child = spawn(command, args, {
+      stdio: 'inherit',
+      cwd: repoRoot,
+      ...options,
+    });
+
+    child.on('error', reject);
+    child.on('exit', (code, signal) => {
+      if (signal) {
+        const err = new Error(`Process exited with signal ${signal}`);
+        err.signal = signal;
+        reject(err);
+      } else if (code === 0) {
+        resolve();
+      } else {
+        const err = new Error(`Process exited with code ${code}`);
+        err.code = code ?? 1;
+        reject(err);
+      }
+    });
+  });
+}
+
+const modulesMarker = join(repoRoot, 'node_modules', '.modules.yaml');
+const lockfile = join(repoRoot, 'pnpm-lock.yaml');
+const lockfileStamp = join(repoRoot, 'node_modules', '.pnpm-lock.hash');
+const rootPackageJson = join(repoRoot, 'package.json');
+
+function readLockfileHash() {
+  if (!existsSync(lockfile)) {
+    return null;
+  }
+
+  return createHash('sha256').update(readFileSync(lockfile)).digest('hex');
+}
+
+function readRecordedHash() {
+  if (!existsSync(lockfileStamp)) {
+    return null;
+  }
+
+  return readFileSync(lockfileStamp, 'utf-8').trim();
+}
+
+function readWorkspacePackageDirs() {
+  if (!existsSync(rootPackageJson)) {
+    return [];
+  }
+
+  let manifest;
+  try {
+    manifest = JSON.parse(readFileSync(rootPackageJson, 'utf-8'));
+  } catch {
+    return [];
+  }
+
+  const packagesConfig = manifest?.pnpm?.packages;
+  const patterns = Array.isArray(packagesConfig)
+    ? packagesConfig
+    : packagesConfig && typeof packagesConfig === 'object'
+      ? Object.keys(packagesConfig)
+      : [];
+
+  const packageDirs = new Set();
+
+  for (const pattern of patterns) {
+    if (typeof pattern !== 'string' || !pattern.length) {
+      continue;
+    }
+
+    const starIndex = pattern.indexOf('*');
+    if (starIndex === -1) {
+      const candidate = join(repoRoot, pattern);
+      if (existsSync(join(candidate, 'package.json'))) {
+        packageDirs.add(candidate);
+      }
+      continue;
+    }
+
+    const base = pattern.slice(0, starIndex).replace(/[\/]*$/, '');
+    if (!base) {
+      continue;
+    }
+
+    const baseDir = join(repoRoot, base);
+    if (!existsSync(baseDir)) {
+      continue;
+    }
+
+    for (const entry of readdirSync(baseDir, { withFileTypes: true })) {
+      if (!entry.isDirectory()) {
+        continue;
+      }
+
+      const candidate = join(baseDir, entry.name);
+      if (existsSync(join(candidate, 'package.json'))) {
+        packageDirs.add(candidate);
+      }
+    }
+  }
+
+  return [...packageDirs];
+}
+
+const workspacePackageDirs = readWorkspacePackageDirs();
+
+async function ensureNodeDependencies() {
+  const currentHash = readLockfileHash();
+  const recordedHash = readRecordedHash();
+
+  let installReason = null;
+
+  if (!existsSync(modulesMarker)) {
+    installReason = 'workspace Node.js dependencies not found';
+  } else if (currentHash && currentHash !== recordedHash) {
+    installReason = 'lockfile changed';
+  } else {
+    const missingPackages = workspacePackageDirs
+      .filter((dir) => !existsSync(join(dir, 'node_modules')))
+      .map((dir) => relative(repoRoot, dir));
+
+    if (missingPackages.length > 0) {
+      installReason = `missing node_modules in ${missingPackages.join(', ')}`;
+    }
+  }
+
+  if (!installReason) {
+    return;
+  }
+
+  console.log(`Running pnpm install (${installReason})...`);
+
+  const { command, args } = resolvePnpmInvocation(['install', '--recursive']);
+  await run(command, args);
+
+  const refreshedHash = readLockfileHash();
+  if (refreshedHash) {
+    writeFileSync(lockfileStamp, `${refreshedHash}\n`);
+  }
+}
+
+const apiDir = join(repoRoot, 'apps', 'api');
+const prismaSchema = join(apiDir, 'prisma', 'schema.prisma');
+
+function hasGeneratedPrismaClient() {
+  const prismaPackage = join(apiDir, 'node_modules', '@prisma', 'client');
+  if (!existsSync(prismaPackage)) {
+    return false;
+  }
+
+  const pnpmStore = join(apiDir, 'node_modules', '.pnpm');
+  if (!existsSync(pnpmStore)) {
+    return false;
+  }
+
+  for (const entry of readdirSync(pnpmStore)) {
+    if (!entry.startsWith('@prisma+client@')) {
+      continue;
+    }
+
+    const clientIndex = join(
+      pnpmStore,
+      entry,
+      'node_modules',
+      '.prisma',
+      'client',
+      'index.js',
+    );
+
+    if (existsSync(clientIndex)) {
+      return true;
+    }
+  }
+
+  return false;
+}
+
+async function ensurePrismaClient() {
+  if (!existsSync(prismaSchema)) {
+    return;
+  }
+
+  if (!existsSync(join(apiDir, 'node_modules'))) {
+    // node dependencies aren't ready yet; ensureNodeDependencies will handle this
+    return;
+  }
+
+  if (hasGeneratedPrismaClient()) {
+    return;
+  }
+
+  console.log('Generating Prisma Client for API...');
+
+  const { command, args } = resolvePnpmInvocation([
+    '--filter',
+    './apps/api',
+    'exec',
+    'prisma',
+    'generate',
+  ]);
+  await run(command, args);
+}
+
+async function startServices() {
+  const concurrently = (await import('concurrently')).default;
+
+  const { result } = concurrently(
+    [
+      { name: 'api', command: 'pnpm dev:api' },
+      { name: 'web', command: 'pnpm dev:web' },
+      { name: 'recs', command: 'pnpm dev:recs' },
+    ],
+    {
+      prefix: 'name',
+      prefixColors: ['green', 'cyan', 'yellow'],
+      killOthers: ['failure', 'success'],
+    },
+  );
+
+  await result;
+}
+
+(async () => {
+  try {
+    await ensureNodeDependencies();
+    await ensurePrismaClient();
+    await startServices();
+  } catch (error) {
+    if (error && typeof error === 'object' && 'code' in error && typeof error.code === 'number') {
+      process.exit(error.code);
+    }
+    console.error(error instanceof Error ? error.message : error);
+    process.exit(1);
+  }
+})();

--- a/scripts/run-recs-dev.mjs
+++ b/scripts/run-recs-dev.mjs
@@ -1,12 +1,80 @@
 #!/usr/bin/env node
-import { existsSync } from 'node:fs';
+import crypto from 'node:crypto';
+import { existsSync, readFileSync, writeFileSync } from 'node:fs';
 import { join } from 'node:path';
-import { spawn } from 'node:child_process';
+import { spawn, spawnSync } from 'node:child_process';
 
 const repoRoot = process.cwd();
+const venvDir = join(repoRoot, '.venv');
 const venvPython = process.platform === 'win32'
-  ? join(repoRoot, '.venv', 'Scripts', 'python.exe')
-  : join(repoRoot, '.venv', 'bin', 'python');
+  ? join(venvDir, 'Scripts', 'python.exe')
+  : join(venvDir, 'bin', 'python');
+const requirementsFile = join(repoRoot, 'apps', 'recs', 'requirements.txt');
+const requirementsStamp = join(venvDir, '.recs-requirements.sha');
+
+function runSync(command, args, options = {}) {
+  const result = spawnSync(command, args, {
+    cwd: repoRoot,
+    stdio: 'inherit',
+    ...options,
+  });
+
+  if (result.status !== 0) {
+    process.exit(result.status ?? 1);
+  }
+
+  return result;
+}
+
+function findPythonInterpreter() {
+  const candidates = process.platform === 'win32'
+    ? ['python', 'py']
+    : ['python3', 'python'];
+
+  for (const candidate of candidates) {
+    const check = spawnSync(candidate, ['--version'], {
+      stdio: 'ignore',
+    });
+
+    if (check.status === 0) {
+      return candidate;
+    }
+  }
+
+  return null;
+}
+
+if (!existsSync(venvPython)) {
+  const interpreter = findPythonInterpreter();
+
+  if (!interpreter) {
+    console.error(
+      'Unable to find a Python interpreter. Please install Python 3.11 and re-run `pnpm dev`.',
+    );
+    process.exit(1);
+  }
+
+  console.log('Creating Python virtual environment for recommendations service...');
+  runSync(interpreter, ['-m', 'venv', venvDir]);
+}
+
+if (existsSync(requirementsFile)) {
+  const requirementsHash = crypto
+    .createHash('sha256')
+    .update(readFileSync(requirementsFile))
+    .digest('hex');
+
+  let existingHash = null;
+  if (existsSync(requirementsStamp)) {
+    existingHash = readFileSync(requirementsStamp, 'utf-8').trim();
+  }
+
+  if (requirementsHash !== existingHash) {
+    console.log('Installing Python dependencies for recommendations service...');
+    runSync(venvPython, ['-m', 'pip', 'install', '-r', requirementsFile]);
+    writeFileSync(requirementsStamp, requirementsHash);
+  }
+}
 
 const pythonExecutable = existsSync(venvPython) ? venvPython : 'python';
 


### PR DESCRIPTION
## Summary
- retry migrations after auto-starting the postgres and mongo services via Docker Compose when Prisma cannot reach the configured database
- improve the migrate helper to reuse the project pnpm invocation, surface clearer exit codes, and retain the prior guidance for missing environment variables
- document that `pnpm migrate` now tries to start the Compose services automatically and explain the fallback for environments without Docker

## Testing
- pnpm migrate *(fails when POSTGRES_URL is not configured in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68df385803c88333a5a3bb4c1ae07f25