### PR TITLE
Align API lockfile with package manifests

### DIFF
--- a/apps/api/pnpm-lock.yaml
+++ b/apps/api/pnpm-lock.yaml
@@ -9,7 +9,7 @@ importers:
   .:
     dependencies:
       '@prisma/client':
-        specifier: latest
+        specifier: ^6.16.3
         version: 6.16.3(prisma@6.16.3(typescript@5.9.3))(typescript@5.9.3)
       bcryptjs:
         specifier: ^2.4.3
@@ -76,7 +76,7 @@ importers:
         specifier: ^29.7.0
         version: 29.7.0(@types/node@20.19.18)(ts-node@10.9.2(@types/node@20.19.18)(typescript@5.9.3))
       prisma:
-        specifier: latest
+        specifier: ^6.16.3
         version: 6.16.3(typescript@5.9.3)
       supertest:
         specifier: ^6.3.4

--- a/infra/README.md
+++ b/infra/README.md
@@ -1,0 +1,17 @@
+# Production Docker Setup
+
+This directory contains the production-oriented Docker Compose stack. To run it:
+
+1. Copy the example environment file and fill in your secrets:
+   ```bash
+   cp infra/env.prod.example infra/env.prod
+   ```
+2. Edit `infra/env.prod` and replace the placeholder values with the credentials for your deployment (database password, JWT secret, Stripe keys, etc.). Ensure `POSTGRES_PASSWORD` matches the password embedded in `DATABASE_URL`.
+3. Launch the services in detached mode:
+   ```bash
+   docker compose -f infra/docker-compose.prod.yml up -d
+   ```
+4. When you're done, shut the stack down with:
+   ```bash
+   docker compose -f infra/docker-compose.prod.yml down
+   ```

--- a/infra/env.prod.example
+++ b/infra/env.prod.example
@@ -1,0 +1,15 @@
+# Environment variables used by docker-compose.prod.yml
+# Copy this file to env.prod and replace placeholder values with your production secrets.
+
+# PostgreSQL configuration (shared between the database container and the API)
+POSTGRES_PASSWORD=change-me
+DATABASE_URL=postgres://postgres:change-me@postgres:5432/shop?schema=public
+
+# MongoDB connection string consumed by the API service
+MONGO_URL=mongodb://mongo:27017/shop
+
+# API secrets
+JWT_SECRET=replace-with-strong-secret
+APP_URL=http://localhost:8085
+STRIPE_SECRET_KEY=sk_live_or_test_key
+STRIPE_WEBHOOK_SECRET=whsec_your_webhook_secret


### PR DESCRIPTION
## Summary
- update the API pnpm lockfile to use the ^6.16.3 specifier for prisma packages so it matches package.json

## Testing
- docker compose -f infra/docker-compose.prod.yml build --no-cache api *(fails: docker unavailable in CI container)*

------
https://chatgpt.com/codex/tasks/task_e_68e07b7d54688333bf64982eb2991e5c