### PR TITLE
Fix missing brand field in home page product type

### DIFF
--- a/apps/web/app/page.tsx
+++ b/apps/web/app/page.tsx
@@ -34,6 +34,7 @@ type Product = {
   slug: string;
   price: number;
   images?: string[];
+  brand?: string;
   defaultVariantId?: string;
   variants?: ProductVariant[];
 };


### PR DESCRIPTION
## Summary
- add the optional `brand` field to the home page `Product` type so the brand label can compile safely

## Testing
- pnpm --filter @apps/web build

------
https://chatgpt.com/codex/tasks/task_e_68e0843b681483339482986f9875f56b