### PR TITLE
Automate database migrations and seeding during API container startup

### DIFF
--- a/apps/api/Dockerfile
+++ b/apps/api/Dockerfile
@@ -27,9 +27,13 @@ RUN pnpm build
 FROM node:20-alpine AS prod
 WORKDIR /usr/src/app
 ENV NODE_ENV=production
+RUN corepack enable && corepack prepare pnpm@9.0.0 --activate
 COPY --from=build /usr/src/app/package.json ./package.json
 COPY --from=build /usr/src/app/node_modules ./node_modules
 COPY --from=build /usr/src/app/dist ./dist
 COPY apps/api/prisma ./prisma
+COPY apps/api/docker-entrypoint.sh ./docker-entrypoint.sh
+RUN chmod +x ./docker-entrypoint.sh
 EXPOSE 4000
+ENTRYPOINT ["./docker-entrypoint.sh"]
 CMD ["node","dist/index.js"]

--- a/apps/api/docker-entrypoint.sh
+++ b/apps/api/docker-entrypoint.sh
@@ -1,0 +1,72 @@
+#!/bin/sh
+set -euo pipefail
+
+normalize_bool() {
+  case "${1:-}" in
+    1|true|TRUE|True|yes|YES|Yes|on|ON|On)
+      echo "true"
+      ;;
+    0|false|FALSE|False|no|NO|No|off|OFF|Off)
+      echo "false"
+      ;;
+    *)
+      echo ""
+      ;;
+  esac
+}
+
+should_setup_db=""
+requested_setup="$(normalize_bool "${AUTO_DB_SETUP:-}")"
+if [ -n "$requested_setup" ]; then
+  should_setup_db="$requested_setup"
+else
+  node_env_lower="$(printf '%s' "${NODE_ENV:-}" | tr '[:upper:]' '[:lower:]')"
+  if [ "$node_env_lower" = "production" ]; then
+    should_setup_db="true"
+  fi
+fi
+
+setup_marker=".db-setup-done"
+
+if [ "$should_setup_db" = "true" ] && [ ! -f "$setup_marker" ]; then
+  echo "[entrypoint] Running database migrations..."
+  migrate_attempt=0
+  while true; do
+    if pnpm prisma:migrate; then
+      break
+    fi
+    migrate_attempt=$((migrate_attempt + 1))
+    if [ $migrate_attempt -ge 5 ]; then
+      echo "[entrypoint] Prisma migrations failed after $migrate_attempt attempts; aborting." >&2
+      exit 1
+    fi
+    echo "[entrypoint] Prisma migrations failed (attempt $migrate_attempt). Retrying in 5 seconds..."
+    sleep 5
+  done
+
+  echo "[entrypoint] Seeding databases..."
+  seed_attempt=0
+  while true; do
+    if pnpm prisma:seed; then
+      break
+    fi
+    seed_attempt=$((seed_attempt + 1))
+    if [ $seed_attempt -ge 5 ]; then
+      echo "[entrypoint] Seeding failed after $seed_attempt attempts; aborting." >&2
+      exit 1
+    fi
+    echo "[entrypoint] Seeding failed (attempt $seed_attempt). Retrying in 5 seconds..."
+    sleep 5
+  done
+
+  touch "$setup_marker"
+  echo "[entrypoint] Database ready."
+else
+  if [ "$should_setup_db" != "true" ]; then
+    echo "[entrypoint] AUTO_DB_SETUP disabled; skipping migrations and seed."
+  else
+    echo "[entrypoint] Database already prepared; skipping migrations and seed."
+  fi
+fi
+
+exec "$@"

--- a/apps/web/app/page.tsx
+++ b/apps/web/app/page.tsx
@@ -34,6 +34,7 @@ type Product = {
   slug: string;
   price: number;
   images?: string[];
+  brand?: string;
   defaultVariantId?: string;
   variants?: ProductVariant[];
 };

--- a/infra/README.md
+++ b/infra/README.md
@@ -11,6 +11,8 @@ This directory contains the production-oriented Docker Compose stack. To run it:
    ```bash
    docker compose -f infra/docker-compose.prod.yml up -d
    ```
+   On first boot the API container automatically applies Prisma migrations and seeds the demo catalog so the storefront has data
+   out of the box. Set `AUTO_DB_SETUP=0` in `infra/env.prod` if you prefer to manage migrations and seeds manually.
 4. When you're done, shut the stack down with:
    ```bash
    docker compose -f infra/docker-compose.prod.yml down

--- a/infra/env.prod.example
+++ b/infra/env.prod.example
@@ -1,6 +1,10 @@
 # Environment variables used by docker-compose.prod.yml
 # Copy this file to env.prod and replace placeholder values with your production secrets.
 
+# Database automation
+# Leave commented (default) to automatically run migrations and seed the demo data when the API container starts.
+#AUTO_DB_SETUP=1
+
 # PostgreSQL configuration (shared between the database container and the API)
 POSTGRES_PASSWORD=change-me
 DATABASE_URL=postgres://postgres:change-me@postgres:5432/shop?schema=public


### PR DESCRIPTION
## Summary
- add an API Docker entrypoint that runs Prisma migrations and seeds the catalog on production container boot
- ensure pnpm is available in the runtime image and document the AUTO_DB_SETUP toggle for docker deployments

## Testing
- pnpm --filter @apps/api build

------
https://chatgpt.com/codex/tasks/task_e_68e0843b681483339482986f9875f56b