### PR TITLE
Ensure API Docker image bundles source files for seeding

### DIFF
--- a/apps/api/Dockerfile
+++ b/apps/api/Dockerfile
@@ -31,6 +31,7 @@ RUN corepack enable && corepack prepare pnpm@9.0.0 --activate
 COPY --from=build /usr/src/app/package.json ./package.json
 COPY --from=build /usr/src/app/node_modules ./node_modules
 COPY --from=build /usr/src/app/dist ./dist
+COPY --from=build /usr/src/app/src ./src
 COPY apps/api/prisma ./prisma
 COPY apps/api/docker-entrypoint.sh ./docker-entrypoint.sh
 RUN chmod +x ./docker-entrypoint.sh


### PR DESCRIPTION
## Summary
- copy the compiled source directory into the production API image so prisma seed scripts can resolve db helpers

## Testing
- docker build -f apps/api/Dockerfile -t ecom-api-test . *(fails: `docker` command is unavailable in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e0a585a3bc8333905e500f2c22f95d