### PR TITLE
Verify catalog data before skipping API seed

### DIFF
--- a/apps/api/Dockerfile
+++ b/apps/api/Dockerfile
@@ -31,6 +31,7 @@ RUN corepack enable && corepack prepare pnpm@9.0.0 --activate
 COPY --from=build /usr/src/app/package.json ./package.json
 COPY --from=build /usr/src/app/node_modules ./node_modules
 COPY --from=build /usr/src/app/dist ./dist
+COPY --from=build /usr/src/app/src ./src
 COPY apps/api/prisma ./prisma
 COPY apps/api/docker-entrypoint.sh ./docker-entrypoint.sh
 RUN chmod +x ./docker-entrypoint.sh


### PR DESCRIPTION
## Summary
- ensure the API entrypoint verifies Mongo catalog collections before skipping migrations and seed
- reuse container networking overrides and force reseeding when the catalog is empty or unreachable

## Testing
- pnpm --filter @apps/api build

------
https://chatgpt.com/codex/tasks/task_e_68e0a585a3bc8333905e500f2c22f95d