### PR TITLE
fix: handle storefront api base fallback

### DIFF
--- a/apps/web/lib/api.ts
+++ b/apps/web/lib/api.ts
@@ -1,7 +1,44 @@
 import { authHeaders } from './auth';
 import { getSessionId } from './session';
 
-export const API_BASE = process.env.NEXT_PUBLIC_API_BASE || '/api';
+const configuredApiBase = process.env.NEXT_PUBLIC_API_BASE;
+const LOCAL_HOSTNAMES = new Set(['localhost', '127.0.0.1', '0.0.0.0', '::1', '[::1]']);
+
+function resolveApiBase(): string {
+  if (typeof window === 'undefined') {
+    return configuredApiBase || '/api';
+  }
+
+  if (!configuredApiBase) return '/api';
+
+  try {
+    const url = new URL(configuredApiBase, window.location.origin);
+
+    const configuredIsLocal = LOCAL_HOSTNAMES.has(url.hostname);
+    const currentIsLocal = LOCAL_HOSTNAMES.has(window.location.hostname);
+
+    if (configuredIsLocal && !currentIsLocal) {
+      return '/api';
+    }
+
+    if (url.origin === window.location.origin) {
+      return url.pathname.endsWith('/') ? url.pathname.slice(0, -1) : url.pathname || '/api';
+    }
+
+    const normalized = url.toString();
+    return normalized.endsWith('/') ? normalized.slice(0, -1) : normalized;
+  } catch (error) {
+    if (process.env.NODE_ENV !== 'production') {
+      console.warn('Invalid NEXT_PUBLIC_API_BASE, falling back to /api', error);
+    }
+    return '/api';
+  }
+}
+
+function withApiBase(path: string): string {
+  const base = resolveApiBase();
+  return `${base}${path}`;
+}
 
 export class ApiError extends Error {
   status: number;
@@ -38,7 +75,7 @@ async function handleError(res: Response) {
 }
 
 export async function apiGet<T>(path: string): Promise<T> {
-  const res = await fetch(`${API_BASE}${path}`, {
+  const res = await fetch(withApiBase(path), {
     cache: 'no-store',
     headers: buildHeaders(),
   });
@@ -47,7 +84,7 @@ export async function apiGet<T>(path: string): Promise<T> {
 }
 
 export async function apiPost<T>(path: string, body: any): Promise<T> {
-  const res = await fetch(`${API_BASE}${path}`, {
+  const res = await fetch(withApiBase(path), {
     method: 'POST',
     headers: buildHeaders({ 'Content-Type': 'application/json' }),
     body: JSON.stringify(body),


### PR DESCRIPTION
## Summary
- make the web client detect unusable localhost API bases and fall back to the reverse-proxied /api origin
- document the fallback so remote browsers know to rebuild the storefront with a reachable origin

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e0c9d4d29883339cc4b9afa0455b53